### PR TITLE
Fix get_batch_result_iter

### DIFF
--- a/salesforce_bulk/salesforce_bulk.py
+++ b/salesforce_bulk/salesforce_bulk.py
@@ -444,6 +444,13 @@ class SalesforceBulk(object):
         uri = self.endpoint + \
             "/services/async/29.0/job/%s/batch/%s/result" % (job_id, batch_id)
         r = requests.get(uri, headers=self.headers(), stream=True)
+
+        result_id = r.text.split("<result>")[1].split("</result>")[0]
+
+        uri = self.endpoint + \
+            "/services/async/29.0/job/%s/batch/%s/result/%s" % (job_id, batch_id, result_id)
+        r = requests.get(uri, headers=self.headers(), stream=True)
+        
         if parse_csv:
             return csv.DictReader(r.iter_lines(chunk_size=2048), delimiter=",",
                                   quotechar='"')


### PR DESCRIPTION
Previous get_batch_result_iter would return something like ```<result-list xmlns="http://www.force.com/2009/06/asyncapi/dataload"><result>72340000000OOGG</result></result-list>```, rather than the result list itself. I added another endpoint hit to retrieve the actual results.