### PR TITLE
Remove redundant `/services/async/29.0` in SF URI

### DIFF
--- a/salesforce_bulk/salesforce_bulk.py
+++ b/salesforce_bulk/salesforce_bulk.py
@@ -457,7 +457,7 @@ class SalesforceBulk(object):
         result_id = r.text.split("<result>")[1].split("</result>")[0]
 
         uri = self.endpoint + \
-            "/services/async/29.0/job/%s/batch/%s/result/%s" % (job_id, batch_id, result_id)
+            "/job/%s/batch/%s/result/%s" % (job_id, batch_id, result_id)
         r = requests.get(uri, headers=self.headers(), stream=True)
         
         if parse_csv:


### PR DESCRIPTION
The `/services/async/29.0` is now redundant in the string concat rendering `get_batch_result_iter` unusable. Now attempts to fetch the result return an `InvalidUrl` from salesforce:

```
2015-06-30 00:51:08,797 - requests.packages.urllib3.connectionpool - DEBUG - "GET /services/async/29.0/services/async/29.0/job/XXX/batch/XXX/result/XXX HTTP/1.1" 400 None
['<?xml version="1.0" encoding="UTF-8"?><error', '   xmlns="http://www.force.com/2009/06/asyncapi/dataload">', ' <exceptionCode>InvalidUrl</exceptionCode>', " <exceptionMessage>Failed to parse URL. Was expecting 'job' but found:services</exceptionMessage>", '</error>']
```

This was caused by merging of https://github.com/heroku/salesforce-bulk/pull/13