### PR TITLE
Switches the csv library to unicodecsv

### DIFF
--- a/salesforce_bulk/csv_adapter.py
+++ b/salesforce_bulk/csv_adapter.py
@@ -1,4 +1,4 @@
-import csv
+import unicodecsv as csv
 from cStringIO import StringIO
 
 class CsvDictsAdapter(object):

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ packages = [
 requires = [
     'httplib2>=0.7.5',
     'requests>=2.2.1',
+    'unicodecsv>=0.13.0',
 ]
 
 with open('README.md') as f:


### PR DESCRIPTION
Without it, bulk uploading data that has unicode characters will fail.

It is api compatible with csv, so nothing else needs to change.
