### PR TITLE
Updated REAMDE.md to link to salesforce-bulkipy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+### Note: This library is NOT actively maintained and has a bunch of issues that have NOT been fixed. This may result in failure to use this library. Have a look at [salesforce-bulkipy](https://github.com/wingify/salesforce-bulkipy), a fork of this library which works, is tested, updated and supports more features.
+
 # Salesforce Bulk
 
 Python client library for accessing the asynchronous Salesforce.com Bulk API.


### PR DESCRIPTION
The salesforce-bulk library was used to export 18k records to wingify salesforce. However, the library is broken, not maintained anymore and is a pain to work with. I had to make code changes in the library installed in my virtualenv to actually get it to work. It took ~week to figure out all the issues we were facing.


1. Added 2 factor auth support: The current library doesn’t work through API but by simply scraping and working with the main login form. If 2 factor auth is enabled (most organizations have it enabled for their salesforce), a page pops up asking for verfication code and it crashes. Solution: Integrated the simple-salesforce library login workaround, where we use the sessionid and host instead.
2. Added support for sandbox: The current library has no support for sandbox
3. Added unicode character parsing feature: Bulk loading data from csv that as unicode character fails. Unicode characters are commonplace and we had them in our salesforce data export as well. The script kept crashing
4. Other bug fixes