### PR TITLE
Update bulk_states.py

### DIFF
--- a/salesforce_bulk/bulk_states.py
+++ b/salesforce_bulk/bulk_states.py
@@ -5,6 +5,5 @@ COMPLETED = 'Completed'
 
 ERROR_STATES = (
     ABORTED,
-    FAILED,
-    NOT_PROCESSED,
+    FAILED
 )


### PR DESCRIPTION
NOT_PROCESSED = 'NotProcessed' is not considered error state
This eventually causes issue for is_batch_done function in salesforce_bulk.py.

```
if batch_state in bulk_states.ERROR_STATES:
    status = self.batch_status(batch_id, job_id)
    raise BulkBatchFailed(job_id, batch_id, status.get('stateMessage'), batch_state)
```

When I am looping using the example in readme:
```
while not bulk.is_batch_done(batch_id):
  sleep(10)
```

the function always raises exception when state is in not processed.