### PR TITLE
Remove the no longer used tox file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ build/*
 dist/*
 *.pyc
 .cache/
-.tox/

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,0 @@
-# content of: tox.ini , put in same dir as setup.py
-[tox]
-envlist = py35,py36,py37,py38
-
-[testenv]
-deps=pytest
-    mock
-commands=pytest
-passenv=SALESFORCE_BULK_TEST_*


### PR DESCRIPTION
* After migrating to Github Workflows, we no longer need to use `tox`. This PR remove the no longer used `tox.ini` file and a reference to `.tox/` in the `.gitignore` file.