### PR TITLE
Set `GUSINFO` team and product tag in `CODEOWNERS`

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,5 @@
 # Comment line immediately above ownership line is reserved for related other information. Please be careful while editing.
 #ECCN:Open Source
-#GUSINFO:
+#GUSINFO:Heroku EDIT,Heroku Connect
 
 * @heroku/edit-team


### PR DESCRIPTION
The `#GUSINFO:` line in `CODEOWNERS` is empty, so it names neither a team nor a product tag. This change sets it to `Heroku EDIT,Heroku Connect`.

This correction was suggested by Claude Code, based on the GitHub owner team and its active product tag in GUS. The reviewer should confirm the new product tag is correct and the most appropriate one for this component.

GUS-W-23525396.